### PR TITLE
Add diff mode to compare two flamegraphs

### DIFF
--- a/src/flame.rs
+++ b/src/flame.rs
@@ -19,6 +19,8 @@ pub struct StackInfo {
     pub level: usize,
     pub width_factor: f64,
     pub hit: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub diff: Option<i64>,
 }
 
 #[derive(Debug, Clone)]
@@ -130,6 +132,8 @@ pub struct FlameGraph {
     pub ordered_stacks: Ordered,
     hits: Option<Hits>,
     sorted: bool,
+    pub diff_mode: bool,
+    pub max_abs_diff: u64,
 }
 
 impl FlameGraph {
@@ -151,6 +155,7 @@ impl FlameGraph {
             children: Vec::<StackIdentifier>::new(),
             level: 0,
             hit: false,
+            diff: None,
         });
         let mut last_line_index = 0;
         let mut counts: HashMap<String, Count> = HashMap::new();
@@ -229,6 +234,8 @@ impl FlameGraph {
             ordered_stacks: ordered,
             hits: None,
             sorted,
+            diff_mode: false,
+            max_abs_diff: 0,
         };
         out.populate_levels(&ROOT_ID, 0, None);
         out
@@ -300,6 +307,7 @@ impl FlameGraph {
                 children: Vec::<StackIdentifier>::new(),
                 level,
                 hit: false,
+                diff: None,
             });
             let stack_id = stacks.len() - 1;
             stacks.get_mut(parent_id).unwrap().children.push(stack_id);
@@ -457,6 +465,47 @@ impl FlameGraph {
         descendants
     }
 
+    /// Compute per-frame diff against a baseline ("before") flamegraph, following
+    /// flamegraph.pl's differential coloring semantics: the delta is the change in
+    /// *self-time* for each frame (`after.self_count - before.self_count`), not the
+    /// change in total_count. This matches flamegraph.pl's `flow()` behaviour where
+    /// the delta is attributed only to the leaf of each folded stack, so common
+    /// non-leaf ancestors stay neutral even when descendants moved. Width is driven
+    /// by this ("after") graph's totals; stacks only present in the baseline are not
+    /// drawn, consistent with flamegraph.pl (use the inverse diff + --negate to see
+    /// them, just like flamegraph.pl).
+    pub fn set_diff_against(&mut self, before: &FlameGraph) {
+        // O(1) lookup by full path; tied to `before`'s borrow for the scope of this fn.
+        let before_index: HashMap<&str, u64> = before
+            .stacks
+            .iter()
+            .filter(|s| s.id != ROOT_ID)
+            .map(|s| (before.get_stack_full_name_from_info(s), s.self_count))
+            .collect();
+
+        let mut max_abs: u64 = 0;
+        let deltas: Vec<i64> = self
+            .stacks
+            .iter()
+            .map(|stack| {
+                // Root carries no self samples in either graph; keep it neutral.
+                if stack.id == ROOT_ID {
+                    return 0i64;
+                }
+                let full_name = &self.data[stack.line_index..stack.end_index];
+                let before_self = before_index.get(full_name).copied().unwrap_or(0);
+                let delta = stack.self_count as i64 - before_self as i64;
+                max_abs = max_abs.max(delta.unsigned_abs());
+                delta
+            })
+            .collect();
+        for (stack, delta) in self.stacks.iter_mut().zip(deltas.iter()) {
+            stack.diff = Some(*delta);
+        }
+        self.max_abs_diff = max_abs;
+        self.diff_mode = true;
+    }
+
     pub fn set_hits(&mut self, p: &SearchPattern) {
         self.stacks.iter_mut().for_each(|stack| {
             stack.hit =
@@ -529,6 +578,8 @@ mod tests {
         pub level: usize,
         pub width_factor: f64,
         pub hit: bool,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub diff: Option<i64>,
         pub short_name: &'a str,
         pub full_name: &'a str,
     }
@@ -549,6 +600,7 @@ mod tests {
                     level: stack.level,
                     width_factor: stack.width_factor,
                     hit: stack.hit,
+                    diff: stack.diff,
                     short_name: self.get_stack_short_name_from_info(stack),
                     full_name: self.get_stack_full_name_from_info(stack),
                 })
@@ -611,6 +663,7 @@ mod tests {
                 children: vec![3, 1, 5],
                 level: 0,
                 hit: false,
+                diff: None,
             }
         );
     }
@@ -629,5 +682,54 @@ mod tests {
     #[test]
     fn test_recursive() {
         check_result("tests/data/recursive.txt");
+    }
+
+    #[test]
+    fn test_set_diff_against() {
+        // before: level1-a has level2-a=10, level2-b=20, level2-c=10 (total 40)
+        //         level1-b has level2-d=10, level2-e=20                (total 30)
+        // after:  level1-a has level2-a=10, level2-b=40, level2-c=10 (total 60)
+        //         level1-b has level2-e=10                             (total 10)
+        //         plus brand-new level1-c;level2-f=5
+        let before = "\
+level1-a;level2-a 10
+level1-a;level2-b 20
+level1-a;level2-c 10
+level1-b;level2-d 10
+level1-b;level2-e 20
+";
+        let after = "\
+level1-a;level2-a 10
+level1-a;level2-b 40
+level1-a;level2-c 10
+level1-b;level2-e 10
+level1-c;level2-f 5
+";
+        let before_fg = FlameGraph::from_string(before.to_string(), false);
+        let mut after_fg = FlameGraph::from_string(after.to_string(), false);
+        after_fg.set_diff_against(&before_fg);
+        assert!(after_fg.diff_mode);
+
+        let get = |full: &str| after_fg.get_stack_by_full_name(full).unwrap().diff.unwrap();
+
+        // Non-leaf ancestors are never leaves here, so self_count=0 in both
+        // flamegraphs and the diff is 0 — matching flamegraph.pl which leaves
+        // them neutral even though their total changed.
+        assert_eq!(get("level1-a"), 0);
+        assert_eq!(get("level1-b"), 0);
+        assert_eq!(get("level1-c"), 0);
+        // Unchanged leaves
+        assert_eq!(get("level1-a;level2-a"), 0);
+        assert_eq!(get("level1-a;level2-c"), 0);
+        // Hotter leaf
+        assert_eq!(get("level1-a;level2-b"), 20);
+        // Colder leaf
+        assert_eq!(get("level1-b;level2-e"), -10);
+        // Brand-new leaf
+        assert_eq!(get("level1-c;level2-f"), 5);
+        // Root stays neutral
+        assert_eq!(after_fg.root().diff, Some(0));
+        // Biggest self-count movement: level2-b moved from 20 → 40 (+20).
+        assert_eq!(after_fg.max_abs_diff, 20);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,6 +22,12 @@ struct Args {
     #[clap(long, action, value_name = "echo")]
     echo: bool,
 
+    /// Baseline ("before") folded-stacks file to diff against. The positional
+    /// filename (or stdin) is treated as "after". Unchanged frames are rendered
+    /// neutral; hotter frames shift toward red, colder toward blue.
+    #[clap(long, value_name = "before-file")]
+    diff: Option<String>,
+
     /// Pid for live flamegraph
     #[cfg(feature = "python")]
     #[clap(long, value_name = "pid")]
@@ -55,7 +61,13 @@ fn get_app_from_filename_or_stdin(args: &Args, echo: bool) -> App {
         println!("{}", content);
     }
     let tic = std::time::Instant::now();
-    let flamegraph = FlameGraph::from_string(content, args.sorted);
+    let mut flamegraph = FlameGraph::from_string(content, args.sorted);
+    if let Some(diff_file) = &args.diff {
+        let before_content =
+            std::fs::read_to_string(diff_file).expect("Could not read diff baseline file");
+        let before = FlameGraph::from_string(before_content, args.sorted);
+        flamegraph.set_diff_against(&before);
+    }
     let mut app = App::with_flamegraph(filename, flamegraph);
     app.add_elapsed("flamegraph", tic.elapsed());
     app

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -27,6 +27,25 @@ const COLOR_SELECTED_STACK: Color = Color::Rgb(250, 250, 250);
 const COLOR_MATCHED_BACKGROUND: Color = Color::Rgb(10, 35, 150);
 const COLOR_TABLE_SELECTED_ROW: Color = Color::Rgb(65, 65, 65);
 
+/// Differential coloring for a stack, following flamegraph.pl's color_scale.
+/// Returns (r, g, b) where unchanged frames are near-neutral gray,
+/// positive deltas (hotter in "after") scale toward red, and
+/// negative deltas (colder in "after") scale toward blue.
+fn diff_color(delta: Option<i64>, max_abs_diff: u64) -> (u8, u8, u8) {
+    let delta = delta.unwrap_or(0);
+    if max_abs_diff == 0 || delta == 0 {
+        return (230, 230, 230);
+    }
+    let ratio = (delta as f64 / max_abs_diff as f64).clamp(-1.0, 1.0);
+    if ratio > 0.0 {
+        let v = (210.0 * (1.0 - ratio)).round() as u8;
+        (255, v, v)
+    } else {
+        let v = (210.0 * (1.0 + ratio)).round() as u8;
+        (v, v, 255)
+    }
+}
+
 #[derive(Debug, Clone, Default)]
 pub struct FlamelensWidgetState {
     frame_height: u16,
@@ -445,22 +464,44 @@ impl<'a> FlamelensWidget<'a> {
             name.hash(&mut hasher);
             hasher.finish() as f64 / u64::MAX as f64
         }
-        let full_name = self.app.flamegraph().get_stack_full_name_from_info(stack);
-        let v1 = hash_name(full_name);
-        let v2 = hash_name(full_name);
+        // In diff mode, suppress the auto-search blue highlight (triggered when
+        // moving the cursor across frames with the same short name) so it does
+        // not mask the differential color. Manual searches (`/foo`, `#`) still win.
+        let search_is_manual = self
+            .app
+            .flamegraph_state()
+            .search_pattern
+            .as_ref()
+            .map(|p| p.is_manual)
+            .unwrap_or(false);
+        let effective_hit = stack.hit
+            && (search_is_manual || !self.app.flamegraph().diff_mode);
         let mut r;
         let mut g;
         let mut b;
-        if !stack.hit {
+        if effective_hit {
+            if let Color::Rgb(r_, g_, b_) = COLOR_MATCHED_BACKGROUND {
+                r = r_;
+                g = g_;
+                b = b_;
+            } else {
+                unreachable!();
+            }
+        } else if self.app.flamegraph().diff_mode {
+            // Differential coloring, mirroring flamegraph.pl's color_scale:
+            // unchanged → neutral, delta>0 → red (hotter in "after"),
+            // delta<0 → blue (colder in "after"). Magnitude scaled by max |delta|.
+            let (dr, dg, db) = diff_color(stack.diff, self.app.flamegraph().max_abs_diff);
+            r = dr;
+            g = dg;
+            b = db;
+        } else {
+            let full_name = self.app.flamegraph().get_stack_full_name_from_info(stack);
+            let v1 = hash_name(full_name);
+            let v2 = hash_name(full_name);
             r = 205 + (50.0 * v2) as u8;
             g = (230.0 * v1) as u8;
             b = (55.0 * v2) as u8;
-        } else if let Color::Rgb(r_, g_, b_) = COLOR_MATCHED_BACKGROUND {
-            r = r_;
-            g = g_;
-            b = b_;
-        } else {
-            unreachable!();
         }
         if let Some(zoom_state) = zoom_state {
             if zoom_state.ancestors.contains(&stack.id) {


### PR DESCRIPTION
Introduces --diff <before-file> flag to color-code changes against a baseline folded-stacks file, mirroring difffolded.pl/flamegraph.pl's differential coloring: unchanged frames stay neutral, frames that got hotter shift toward red, and frames that got colder shift toward blue, scaled by the per-graph maximum absolute delta.